### PR TITLE
Add MOJ Header and display signed in user's name

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -4,7 +4,10 @@
 
 module.exports = {
   // Service name used in header. Eg: 'Renew your passport'
-  serviceName: 'HMPPS - Refer to an intervention',
+  serviceName: 'Make a referral',
+
+  // Name of organisation
+  organisationName: 'GOV.UK',
 
   // Default port that prototype runs on
   port: '3000',

--- a/app/views/includes/banner.html
+++ b/app/views/includes/banner.html
@@ -1,0 +1,46 @@
+{%- from "moj/components/header/macro.njk" import mojHeader -%}
+{# Set serviceName & organisation name in config.js. #}
+{% if isLoggedInPage %}
+
+{{ mojHeader({
+  homepageUrl: "/",
+  organisationLabel: {
+    text: organisationName,
+    href: "/"
+  },
+  serviceLabel: {
+    text: serviceName,
+    href: "/book-and-manage/referral-start"
+  },
+  serviceUrl: "/",
+  containerClasses: "govuk-width-container",
+  navigation: {
+    label: "Account navigation",
+    items: [{
+      text: "James",
+      href: "#"
+    },
+    {
+      text: "Sign out",
+      href: "/book-and-manage/index"
+    }]
+  }
+}) }}
+
+{% else %}
+
+{{ mojHeader({
+  homepageUrl: "/",
+  organisationLabel: {
+    text: organisationName,
+    href: "/"
+  },
+  serviceLabel: {
+    text: serviceName,
+    href: "/book-and-manage/referral-start"
+  },
+  serviceUrl: "/",
+  containerClasses: "govuk-width-container"
+}) }}
+
+{% endif %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -38,14 +38,9 @@
 {% endblock %}
 
 {% block header %}
+  {%- from "moj/components/header/macro.njk" import mojHeader -%}
   {% include "includes/cookie-banner.html" %}
-  {# Set serviceName in config.js. #}
-  {{ govukHeader({
-    homepageUrl: "/",
-    serviceName: serviceName,
-    serviceUrl: "/",
-    containerClasses: "govuk-width-container"
-  }) }}
+  {% include "includes/banner.html" %}
 {% endblock %}
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -308,3 +308,18 @@ exports.handleCookies = function (app) {
     next()
   }
 }
+
+exports.handleBanner = function (app) {
+  return function handleBanner (req, _, next) {
+    const loggedOutPages = ['/', '/index', '/book-and-manage/index']
+    const isLoggedInPage = !loggedOutPages.includes(req.path)
+
+    if (isLoggedInPage) {
+      app.locals.isLoggedInPage = true
+      return next()
+    }
+
+    app.locals.isLoggedInPage = false
+    next()
+  }
+}

--- a/server.js
+++ b/server.js
@@ -51,6 +51,9 @@ documentationApp.use(cookieParser())
 app.use(utils.handleCookies(app))
 documentationApp.use(utils.handleCookies(documentationApp))
 
+// Determine whether to show logged in banner or not
+app.use(utils.handleBanner(app))
+
 // Set up configuration variables
 var releaseVersion = packageJson.version
 var glitchEnv = (process.env.PROJECT_REMIX_CHAIN) ? 'production' : false // glitch.com
@@ -166,6 +169,7 @@ app.locals.cookieText = config.cookieText
 app.locals.promoMode = promoMode
 app.locals.releaseVersion = 'v' + releaseVersion
 app.locals.serviceName = config.serviceName
+app.locals.organisationName = config.organisationName
 // extensionConfig sets up variables used to add the scripts and stylesheets to each page.
 app.locals.extensionConfig = extensions.getAppConfig()
 


### PR DESCRIPTION
For any "logged in pages", we'll display the hardcoded user's name and a sign out link that takes the user to the login page.

It's been tricky to match the designs to the Figma links exactly, particularly the Gov UK logo (which is the MOJ logo in the prototyping kit), but hopefully this is good enough for now.

https://trello.com/c/sjEmzXKA/246-update-header-and-name-sign-out-and-update-start-pages

## Screenshots

### Logged out page

![image](https://user-images.githubusercontent.com/19826940/91299451-8411e800-e799-11ea-8c8b-24e2abf24e57.png)

### Logged in page

![image](https://user-images.githubusercontent.com/19826940/91299490-93913100-e799-11ea-8743-971ea5411e43.png)
