### PR TITLE
Change responsible officer summary list content

### DIFF
--- a/app/views/book-and-manage/make-a-referral/responsible-officer-information.html
+++ b/app/views/book-and-manage/make-a-referral/responsible-officer-information.html
@@ -31,7 +31,7 @@
         <dl class="govuk-summary-list">
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-width-one-third">
-              Responsible officer name
+              Name
             </dt>
             <dd class="govuk-summary-list__value">
               Adam Michaels
@@ -39,7 +39,7 @@
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-width-one-third">
-              Reponsible officer email
+              Email address
             </dt>
             <dd class="govuk-summary-list__value">
               Adam.Michaels@justice.gov.uk
@@ -47,7 +47,7 @@
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-width-one-third">
-              Responsible officer office address
+              Office address
             </dt>
             <dd class="govuk-summary-list__value">
               44 Bouverie Road<br>WESTON LULLINGFIELDS<br>SY4 0RE
@@ -55,7 +55,7 @@
           </div>
           <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key govuk-!-width-one-third">
-              Responsible officer's manager's name
+              Manager name
             </dt>
             <dd class="govuk-summary-list__value">
               Tony Richardson


### PR DESCRIPTION
Remove 'Responsible officer' from description terms - repetition not needed as page is all about responsible officers

Change 'email' to 'email address'

Change 'manager's name' to 'Manager name'