### PR TITLE
Change service user id h1 content

### DIFF
--- a/app/views/book-and-manage/make-a-referral/service-user-id.html
+++ b/app/views/book-and-manage/make-a-referral/service-user-id.html
@@ -28,12 +28,9 @@
       <form action="service-user-details" method="post" class="form">
         {{ govukInput({
           label: {
-            text: "Enter the service user's case identifier",
+            text: "Enter service user CRN, PNC or NOMIS number",
             classes: "govuk-label--xl",
             isPageHeading: true
-          },
-          hint: {
-            text: "You can use the CRN, PNC or Nomis number"
           },
           id: "service-user-id",
           name: "service-user-id",


### PR DESCRIPTION
Change 'Enter the service user's case identifier' to 'Enter service user CRN, PNC or NOMIS number' - users didn't understand what 'case identifier' meant