### PR TITLE
Service provider case worker can manage a referral

### DIFF
--- a/app/caseworkerManageRoutes.js
+++ b/app/caseworkerManageRoutes.js
@@ -1,0 +1,203 @@
+const express = require('express')
+const router = express.Router()
+const moment = require('moment')
+
+router.use(function (req, res, next) {
+    res.locals.serviceName = "Manage intervention referrals"
+    next()
+})
+
+function findReferral(req) {
+    const referral = req.session.data.referrals[req.params.referralIndex];
+
+    for (const intervention of referral.interventions) {
+	// Populate each session’s status based on which events have occurred.
+	if (intervention.actionPlanApproved) {
+	    for (const session of intervention.sessions) {
+		if (session.assessment != null) {
+		    session.status = "completed";
+		} else {
+		    session.status = "pending";
+		    break;
+		}
+	    }
+	}
+
+	// Populate initial assessment status based on which events have occurred.
+	if (intervention.initialAssessmentScheduled) {
+	    intervention.initialAssessmentStatus = "completed";
+	} else {
+	    intervention.initialAssessmentStatus = "not started";
+	}
+
+	// Populate action plan status based on what’s happened to the plan.
+	if (intervention.endOfServiceReport != null) {
+	    intervention.actionPlanStatus = "completed";
+	} else if (intervention.actionPlanApproved) {
+	    intervention.actionPlanStatus = "in progress";
+	} else if (intervention.actionPlanSubmitted) {
+	    intervention.actionPlanStatus = "pending";
+	} else {
+	    intervention.actionPlanStatus = "not started";
+	}
+    }
+
+    return referral;
+}
+
+function findIntervention(req) {
+    const referral = findReferral(req);
+    return referral.interventions[req.params.interventionIndex];
+}
+
+function cssClassForInitialAssessmentStatus(initialAssessmentStatus) {
+    switch (initialAssessmentStatus) {
+	case "completed":
+	    return "govuk-tag";
+	case "not started":
+	    return "govuk-tag govuk-tag--grey";
+	default:
+	    return "";
+    }
+}
+
+function cssClassForActionPlanStatus(actionPlanStatus) {
+    switch (actionPlanStatus) {
+	case "pending":
+	    return "govuk-tag govuk-tag--green";
+	case "in progress":
+	    return "govuk-tag govuk-tag--blue";
+	case "not started":
+	    return "govuk-tag govuk-tag--grey";
+	case "completed":
+	    return "govuk-tag";
+	default: return "";
+    }
+}
+
+function cssClassForSessionStatus(sessionStatus) {
+    switch (sessionStatus) {
+	case "completed":
+	    return "govuk-tag govuk-tag--green";
+	case "pending":
+	    return "govuk-tag";
+	default:
+	    return "";
+    }
+}
+
+router.get("/referrals/:referralIndex", (req, res) => {
+    const referral = findReferral(req);
+
+    res.render("book-and-manage/manage-a-referral/caseworker/referral", { referral, referralIndex: req.params.referralIndex, cssClassForInitialAssessmentStatus, cssClassForActionPlanStatus });
+});
+
+router.get("/referrals/:referralIndex/interventions/:interventionIndex", (req, res) => {
+    const intervention = findIntervention(req);
+
+    const allSessionsCompleted = intervention.sessions.every(intervention => intervention.status === "completed");
+    const readyForEndOfServiceReport = intervention.actionPlanApproved && allSessionsCompleted && intervention.endOfServiceReport == null;
+    const canChangeActionPlan = intervention.endOfServiceReport == null;
+
+    res.render("book-and-manage/manage-a-referral/caseworker/intervention", { intervention, referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, allSessionsCompleted, readyForEndOfServiceReport, canChangeActionPlan, moment, cssClassForSessionStatus, cssClassForActionPlanStatus });
+});
+
+router.post("/referrals/:referralIndex/interventions/:interventionIndex/goals", (req, res) => {
+    const intervention = findIntervention(req);
+
+    const goal = { text: req.body.text };
+    intervention.goals.push(goal);
+
+    res.redirect(`/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
+});
+
+router.post("/referrals/:referralIndex/interventions/:interventionIndex/sessions", (req, res) => {
+    const intervention = findIntervention(req);
+
+    // We don’t yet have a proper “add session” page, so start tomorrow and
+    // increment by a week each time
+    var date;
+    if (intervention.sessions.length > 0) {
+	date = moment(intervention.sessions[intervention.sessions.length - 1].date).add(1, 'week').toDate();
+    } else {
+	date = moment(new Date()).add(1, 'day').toDate();
+    }
+
+    const session = { title: `Session ${intervention.sessions.length + 1}`, date: date, startTime: "17:00", endTime: "18:00" }
+    intervention.sessions.push(session);
+
+    res.redirect(`/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
+});
+
+router.post("/referrals/:referralIndex/interventions/:interventionIndex/action-plan-submission", (req, res) => {
+    const intervention = findIntervention(req);
+    intervention.actionPlanSubmitted = true;
+
+    res.redirect(`/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/action-plan-confirmation`);
+});
+
+router.get("/referrals/:referralIndex/interventions/:interventionIndex/action-plan-confirmation", (req, res) => {
+    const intervention = findIntervention(req);
+
+    res.render("book-and-manage/manage-a-referral/caseworker/action-plan-confirmation", { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention });
+});
+
+router.get("/referrals/:referralIndex/interventions/:interventionIndex/fast-forward/action-plan-approved", (req, res) => {
+    const intervention = findIntervention(req);
+
+    intervention.actionPlanApproved = true;
+
+    res.redirect(`/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
+});
+
+router.get("/referrals/:referralIndex/interventions/:interventionIndex/sessions/:sessionIndex/assessment", (req, res) => {
+    const intervention = findIntervention(req);
+
+    const sessionIndex = parseInt(req.params.sessionIndex);
+
+    res.render("book-and-manage/manage-a-referral/caseworker/assessment", { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention, sessionIndex });
+});
+
+router.post("/referrals/:referralIndex/interventions/:interventionIndex/sessions/:sessionIndex/assessment", (req, res) => {
+    const intervention = findIntervention(req);
+
+    const sessionIndex = parseInt(req.params.sessionIndex);
+
+    intervention.sessions[sessionIndex].assessment = req.body;
+
+    res.redirect(`/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
+});
+
+router.get("/referrals/:referralIndex/interventions/:interventionIndex/fast-forward/sessions-completed", (req, res) => {
+    const intervention = findIntervention(req);
+
+    for (session of intervention.sessions) {
+	if (session.assessment == null) {
+	    session.assessment = {};
+	}
+    }
+
+    res.redirect(`/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}`);
+});
+
+router.get("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report", (req, res) => {
+    const intervention = findIntervention(req);
+
+    res.render("book-and-manage/manage-a-referral/caseworker/end-of-service-report", { referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex, intervention });
+});
+
+router.post("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report", (req, res) => {
+    const intervention = findIntervention(req);
+
+    intervention.endOfServiceReport = req.body;
+
+    res.redirect(`/book-and-manage/manage-a-referral/caseworker/referrals/${req.params.referralIndex}/interventions/${req.params.interventionIndex}/end-of-service-report-confirmation`);
+});
+
+router.get("/referrals/:referralIndex/interventions/:interventionIndex/end-of-service-report-confirmation", (req, res) => {
+    const intervention = findIntervention(req);
+
+    res.render("book-and-manage/manage-a-referral/caseworker/end-of-service-report-confirmation", { intervention, referralIndex: req.params.referralIndex, interventionIndex: req.params.interventionIndex });
+});
+
+module.exports = router

--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -19,8 +19,26 @@ Example usage:
 */
 
 module.exports = {
-  users: [
-    {id: "GB123456"},
-    {id: "EN000001"}
-  ]
+  referrals: [
+    {
+      interventions: [
+	{
+	  name: "Accommodation",
+	  initialAssessmentScheduled: false,
+	  actionPlanSubmitted: false,
+	  actionPlanApproved: false,
+	  goals: [],
+	  sessions: [],
+	},
+	{
+	  name: "Social inclusion",
+	  initialAssessmentScheduled: true,
+	  actionPlanSubmitted: false,
+	  actionPlanApproved: false,
+	  goals: [],
+	  sessions: [],
+	}
+      ]
+    }
+  ],
 }

--- a/app/routes.js
+++ b/app/routes.js
@@ -2,6 +2,7 @@ const express = require("express");
 const communityAPIClient = require("../lib/community_api_client.js");
 const hmppsOauthClient = require("../lib/hmpps_oauth_client.js");
 const router = express.Router();
+const caseworkerManageRouter = require('./caseworkerManageRoutes')
 
 router.get("/service-user-details/show", async function (req, res, next) {
   try {
@@ -22,4 +23,8 @@ router.get("/service-user-details/show", async function (req, res, next) {
   }
 });
 
-module.exports = router;
+router.use("/book-and-manage/manage-a-referral/caseworker", caseworkerManageRouter);
+
+// Add your routes here - above the module.exports line
+
+module.exports = router

--- a/app/views/book-and-manage/manage-a-referral/caseworker/action-plan-confirmation.html
+++ b/app/views/book-and-manage/manage-a-referral/caseworker/action-plan-confirmation.html
@@ -1,0 +1,29 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Action plan sent
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-panel govuk-panel--confirmation">
+	<h1 class="govuk-panel__title">Action plan sent</h1>
+
+	<div class="govuk-panel__body">Your reference number<br><strong>NR0001</strong></div>
+	<br>
+	<div class="govuk-panel__body">Intervention: <strong>{{intervention.name}}<strong></div>
+      </div>
+
+      <p class="govuk-body">Your email has been sent to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+	<li>Josie Bart, PP</li>
+      </ul>
+
+      <p class="govuk-body">
+	<a class="govuk-link" href="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}">Back to Alex’s referral page</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/book-and-manage/manage-a-referral/caseworker/assessment.html
+++ b/app/views/book-and-manage/manage-a-referral/caseworker/assessment.html
@@ -1,0 +1,110 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Session {{sessionIndex + 1}}: assessment
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Session {{sessionIndex + 1}}: assessment</h1>
+
+      <form method="post" action="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{sessionIndex}}/assessment">
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h2 class="govuk-fieldset__heading">Did Alex attend session {{sessionIndex + 1}}?</h2>
+            </legend>
+
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="attended-yes" name="attended" type="radio" value="yes">
+                <label class="govuk-label govuk-radios__label" for="attended-yes">Yes</label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="attended-no" name="attended" type="radio" value="no">
+                <label class="govuk-label govuk-radios__label" for="attended-no">No</label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        {% for aspect in ["behaviour", "attitude", "relationship management skills"] %}
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                <h2 class="govuk-fieldset__heading">Assess Alex’s {{ aspect }}</h2>
+              </legend>
+
+              <div class="govuk-radios">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="{{aspect}}-1" name="{{aspect}}" type="radio" value="1">
+                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-1">1 - Poor</label>
+                </div>
+
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="{{aspect}}-2" name="{{aspect}}" type="radio" value="2">
+                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-2">2 - Fair</label>
+                </div>
+
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="{{aspect}}-3" name="{{aspect}}" type="radio" value="3">
+                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-3">3 - Good</label>
+                </div>
+
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="{{aspect}}-4" name="{{aspect}}" type="radio" value="4">
+                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-4">4 - Very good</label>
+                </div>
+
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="{{aspect}}-5" name="{{aspect}}" type="radio" value="5">
+                  <label class="govuk-label govuk-radios__label" for="{{aspect}}-5">5 - Excellent</label>
+                </div>
+              </div>
+            </fieldset>
+
+          </div>
+
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="{{aspect}}-justification">
+              Why did you give Alex that rating?
+            </label>
+
+            <textarea class="govuk-textarea" id="{{aspect}}-justification" name="{{aspect}}-justification"></textarea>
+          </div>
+        {% endfor %}
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              <h2 class="govuk-fieldset__heading">Do you want to alert the probation practitioner by sending them a copy of the assessment?</h2>
+            </legend>
+
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="alert-yes" name="alert" type="radio" value="yes">
+                <label class="govuk-label govuk-radios__label" for="alert-yes">Yes</label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="alert-no" name="alert" type="radio" value="no">
+                <label class="govuk-label govuk-radios__label" for="alert-no">No</label>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="alert-content">
+            If ‘Yes’, what do you want to alert the probation practitioner about?
+          </label>
+
+          <textarea class="govuk-textarea" id="alert-content" name="alert-content"></textarea>
+        </div>
+
+        <input type="submit" class="govuk-button" data-module="govuk-button" value="Submit the assessment">
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/book-and-manage/manage-a-referral/caseworker/end-of-service-report-confirmation.html
+++ b/app/views/book-and-manage/manage-a-referral/caseworker/end-of-service-report-confirmation.html
@@ -1,0 +1,29 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Action plan sent
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-panel govuk-panel--confirmation">
+	<h1 class="govuk-panel__title">End of service report submitted</h1>
+
+	<div class="govuk-panel__body">Your reference number<br><strong>NR0001</strong></div>
+	<br>
+	<div class="govuk-panel__body">Intervention: <strong>{{intervention.name}}<strong></div>
+      </div>
+
+      <p class="govuk-body">Your email has been sent to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+	<li>Josie Bart, PP</li>
+      </ul>
+
+      <p class="govuk-body">
+	<a class="govuk-link" href="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}">Back to Alex’s referral page</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/book-and-manage/manage-a-referral/caseworker/end-of-service-report.html
+++ b/app/views/book-and-manage/manage-a-referral/caseworker/end-of-service-report.html
@@ -1,0 +1,110 @@
+{#<h1>End of service report</h1>#}
+
+{#<form method="post" action="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/end-of-service-report">#}
+  {#{% for goal in intervention.goals %}#}
+    {#<h2>Did Alex achieve goal {{ loop.index }}?</h2>#}
+    {#<p>{{ intervention.goals[loop.index0].text }}</p>#}
+  {#{% endfor %}#}
+
+  {#<input type="submit" value="Submit the report">#}
+{#</form>#}
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  End of service report
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">End of service report</h1>
+
+      <h2 class="govuk-heading-l">Personal details</h2>
+
+      <dl class="govuk-summary-list">
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Other names</dt>
+	  <dd class="govuk-summary-list__value">Shorty</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Address</dt>
+          <dd class="govuk-summary-list__value">Flat 2<br>27 Test Walk<br>SY16 1AQ<br><br>Private rental</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Nationality</dt>
+	  <dd class="govuk-summary-list__value">British</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Ethnic group</dt>
+	  <dd class="govuk-summary-list__value">White: British</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Preferred language</dt>
+	  <dd class="govuk-summary-list__value">English</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Sex</dt>
+	  <dd class="govuk-summary-list__value">Heterosexual</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Religion or belief</dt>
+	  <dd class="govuk-summary-list__value">None</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Disabilities</dt>
+	  <dd class="govuk-summary-list__value">Autism spectrum condition</dd>
+	</div>
+      </dl>
+
+      <form method="post" action="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/end-of-service-report">
+
+        {% for goal in intervention.goals %}
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                <h2 class="govuk-fieldset__heading">Did Alex achieve goal {{ loop.index }}?</h2>
+              </legend>
+
+              <p class="govuk-body">{{ intervention.goals[loop.index0].text }}</p>
+
+              <div class="govuk-radios">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="goal-{{loop.index0}}-achieved" name="goal-{{loop.index0}}" type="radio" value="achieved">
+                  <label class="govuk-label govuk-radios__label" for="goal-{{loop.index0}}-achieved">Achieved</label>
+                </div>
+
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="goal-{{loop.index0}}-partially-achieved" name="goal-{{loop.index0}}" type="radio" value="partially-achieved">
+                  <label class="govuk-label govuk-radios__label" for="goal-{{loop.index0}}-partially-achieved">Partially achieved</label>
+                </div>
+
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="goal-{{loop.index0}}-not-achieved" name="goal-{{loop.index0}}" type="radio" value="not-achieved">
+                  <label class="govuk-label govuk-radios__label" for="goal-{{loop.index0}}-not-achieved">Not achieved</label>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="goal-{{loop.index0}}-details">
+              Provide details about Alex’s performance during the intervention.
+            </label>
+
+            <textarea class="govuk-textarea" id="goal-{{loop.index0}}-details" name="goal-{{loop.index0}}-details"></textarea>
+          </div>
+        {% endfor %}
+
+        <input type="submit" class="govuk-button" data-module="govuk-button" value="Submit the report">
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/book-and-manage/manage-a-referral/caseworker/intervention.html
+++ b/app/views/book-and-manage/manage-a-referral/caseworker/intervention.html
@@ -1,0 +1,130 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Manage intervention referrals
+{% endblock %}
+
+{% block beforeContent %}
+  <a href="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}" class="govuk-back-link">Back</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">{{ intervention.name }} referral</h1>
+
+      <dl class="govuk-summary-list">
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Relevant sentence</dt>
+	  <dd class="govuk-summary-list__value">Misuse of Drugs Act 1971 s.4(3)<br>Sub category: Misuse of Drugs Act 1971, s.5(3)<br>Date: 01/01/2020<br>Order: Suspended sentence</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Desired outcomes</dt>
+	  <dd class="govuk-summary-list__value">Service user develops resilience and perseverance to cope with challenges and barriers on return to the community.</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Required complexity</dt>
+	  <dd class="govuk-summary-list__value">Low complexity<br>[up to 4 sessions (pre-release virtual contact)] Service user has a low risk of reoffending. Service user has limited family support.</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Completion date required</dt>
+	  <dd class="govuk-summary-list__value">10/01/2021</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Maximum number of RAR days</dt>
+	  <dd class="govuk-summary-list__value">22</dd>
+	</div>
+
+	<div class="govuk-summary-list__row">
+	  <dt class="govuk-summary-list__key">Further information</dt>
+	  <dd class="govuk-summary-list__value">N/A</dd>
+	</div>
+      </dl>
+
+      <h2 class="govuk-heading-l">Action plan</h2>
+
+      <h3 class="govuk-heading-m">Goals</h3>
+      {% for goal in intervention.goals %}
+	<h4 class="govuk-heading-s">Goal {{ loop.index }}</h4>
+	<p class="govuk-body">{{ goal.text }}</p>
+      {% endfor %}
+      {% if canChangeActionPlan %}
+	<form method="post" action="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/goals">
+	  <div class="govuk-form-group">
+	    <label class="govuk-heading-s" for="text">Goal {{ intervention.goals.length + 1 }}</label>
+	    <textarea class="govuk-textarea" id="text" name="text"></textarea>
+	  </div>
+	  <input class="govuk-button govuk-button--secondary" data-module="govuk-button" type="submit" value="Add new goal">
+	</form>
+      {% endif %}
+
+      <h3 class="govuk-heading-m">Sessions</h3>
+      <table class="govuk-table">
+	<thead class="govuk-table__header" class="govuk-table__head">
+	  <tr class="govuk-table-row">
+	    <th class="govuk-table__header" scope="col">Session title</th>
+	    <th class="govuk-table__header" scope="col">Date</th>
+	    <th class="govuk-table__header" scope="col">Time</th>
+	    <th class="govuk-table__header" scope="col">Status</th>
+	    <th class="govuk-table__header" scope="col">Action</th>
+	  </tr>
+	</thead>
+
+	{% for session in intervention.sessions %}
+	  <tr class="govuk-table-row">
+	    <td class="govuk-table__cell">{{ session.title }}</td>
+	    <td class="govuk-table__cell">{{ moment(session.date).format("D/M/YYYY") }}</td>
+	    <td class="govuk-table__cell">{{ session.startTime }} to {{ session.endTime }}</td>
+	    <td class="govuk-table__cell ">
+	      <strong class="{{ cssClassForSessionStatus(session.status) }}">{{ session.status }}</strong>
+	    </td>
+	    <td class="govuk-table__cell">
+	      {% if session.status !== "completed" %}
+		<a class="govuk-link" href="#">Edit</a>
+	      {% endif %}
+
+	      {% if session.status === "completed" %}
+		<a class="govuk-link" href="#">View</a>
+	      {% endif %}
+
+	      {% if session.status === "pending" %}
+		<a class="govuk-link" href="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions/{{loop.index0}}/assessment">Assess</a>
+	      {% endif %}
+	    </td>
+	  </tr>
+	{% endfor %}
+      </table>
+
+      {% if canChangeActionPlan %}
+	<form method="post" action="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/sessions">
+	  <input class="govuk-button govuk-button--secondary" data-module="govuk-button" type="submit" value="Add new session">
+	</form>
+      {% endif %}
+
+      {% if not intervention.actionPlanSubmitted %}
+	<form method="post" action="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/action-plan-submission">
+	  <input class="govuk-button" data-module="govuk-button" type="submit" value="Submit for approval">
+	</form>
+      {% endif %}
+
+      <p class="govuk-body">
+      {% if readyForEndOfServiceReport %}
+	<a class="govuk-button" data-module="govuk-button" href="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/end-of-service-report">Complete end of service report</a>
+      {% endif %}
+
+      {% if intervention.actionPlanSubmitted and not intervention.actionPlanApproved %}
+	<a class="govuk-link" href="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/action-plan-approved">Fast-forward to action plan approved</a>
+      {% endif %}
+
+      {% if intervention.actionPlanApproved and not allSessionsCompleted %}
+	<a class="govuk-link" href="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{interventionIndex}}/fast-forward/sessions-completed">Fast-forward to sessions completed</a>
+      {% endif %}
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/book-and-manage/manage-a-referral/caseworker/referral.html
+++ b/app/views/book-and-manage/manage-a-referral/caseworker/referral.html
@@ -1,0 +1,95 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Referral details
+{% endblock %}
+
+{% block beforeContent %}
+  <a href="#" class="govuk-back-link">Return to cases and referrals</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-column">
+    <div class="govuk-grid-row-two-thirds">
+      <div class="govuk-tabs" data-module="govuk-tabs">
+	<h2 class="govuk-tabs__title">
+	  Contents
+	</h2>
+	<ul class="govuk-tabs__list">
+	  <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+	    <a class="govuk-tabs__tab" href="#intervention-progress">
+	      Intervention progress
+	    </a>
+	  </li>
+	  <li class="govuk-tabs__list-item">
+	    <a class="govuk-tabs__tab" href="#referral-details">
+	      Referral details
+	    </a>
+	  </li>
+	</ul>
+	<div class="govuk-tabs__panel" id="intervention-progress">
+	  <h2 class="govuk-heading-l">Initial assessment</h2>
+	  <table class="govuk-table">
+	    <thead class="govuk-table__head">
+	      <tr class="govuk-table__row">
+		<th scope="col" class="govuk-table__header">Intervention</th>
+		<th scope="col" class="govuk-table__header">Status</th>
+		<th scope="col" class="govuk-table__header">Action</th>
+	      </tr>
+	    </thead>
+	    <tbody class="govuk-table__body">
+	      {% for intervention in referral.interventions %}
+		<tr class="govuk-table__row">
+		  <td class="govuk-table__cell">{{ intervention.name }}</td>
+		  <td class="govuk-table__cell"><strong class="{{ cssClassForInitialAssessmentStatus(intervention.initialAssessmentStatus) }}">{{ intervention.initialAssessmentStatus }}</strong></td>
+		  {% if intervention.initialAssessmentScheduled %}
+		    <td class="govuk-table__cell"><a class="govuk-link" href="#">View</a></td>
+		  {% else %}
+		    <td class="govuk-table__cell"><a class="govuk-link" href="#">Schedule</a></td>
+		  {% endif %}
+		</tr>
+	      {% endfor %}
+	    </tbody>
+	  </table>
+
+	  <h2 class="govuk-heading-l">Action plan</h2>
+	  <table class="govuk-table">
+	    <thead class="govuk-table__head">
+	      <tr class="govuk-table__row">
+		<th scope="col" class="govuk-table__header">Intervention</th>
+		<th scope="col" class="govuk-table__header">Status</th>
+		<th scope="col" class="govuk-table__header">Action</th>
+	      </tr>
+	    </thead>
+	    <tbody class="govuk-table__body">
+	      {% for intervention in referral.interventions %}
+		{% if intervention.initialAssessmentScheduled %}
+		  <tr class="govuk-table__row">
+		    <td class="govuk-table__cell">Social inclusion</td>
+		    <td class="govuk-table__cell"><strong class="{{cssClassForActionPlanStatus(intervention.actionPlanStatus)}}">{{intervention.actionPlanStatus}}</strong></td>
+		    <td class="govuk-table__cell">
+		      <a class="govuk-link" href="/book-and-manage/manage-a-referral/caseworker/referrals/{{referralIndex}}/interventions/{{loop.index0}}">
+			{% if intervention.actionPlanStatus == "pending" or intervention.actionPlanStatus == "completed" %}
+			  View
+			{% elif intervention.actionPlanStatus == "in progress" %}
+			  Edit
+			{% elif intervention.actionPlanStatus == "not started" %}
+			  Set up
+			{% endif %}
+		      </a>
+		    </td>
+		  </tr>
+		{% endif %}
+	      {% endfor %}
+	    </tbody>
+	  </table>
+	</div>
+	<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="referral-details">
+	  <h2 class="govuk-heading-l">Referral details</h2>
+
+	  <p class="govuk-body">To-do</p>
+	</div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -43,6 +43,12 @@
               <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
             </svg>
           </a>
+          <a href="book-and-manage/manage-a-referral/caseworker/referrals/0" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+            Case worker: manage intervention referrals
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+            </svg>
+          </a>
         </ul>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "inquirer": "^7.1.0",
     "keypather": "^3.0.0",
     "marked": "^0.8.2",
+    "moment": "^2.28.0",
     "notifications-node-client": "^4.7.2",
     "nunjucks": "^3.2.1",
     "portscanner": "^2.1.1",


### PR DESCRIPTION
# What's new

This introduces the _end_ of the case worker journey. It focuses on a
single referral, which has already had its initial appointment
scheduled. I started here because it seems like the gnarliest part of
the journey, logic-wise.

There are fast-forward links to allow a user research session to skip
past points in the journey that would require interaction from a third
party, or to skip repetitive actions.

This is based on the bottom half of the “Receive a referral caseworker”
Figma board [1].

I haven’t yet built the header which contains details of the referral
and the service user.

This introduces Moment as a dependency, for manipulating and displaying
dates.

I’ve made some assumptions about the meaning of the various statuses
that are displayed in the journeys. No doubt the correct meanings will
crystallize over time.

[1] https://www.figma.com/file/uHcKdueAgFtYyeAURhBuNw/Receive-a-referral-caseworker

# What's next

- Build the start of the case worker journey, by introducing a list of referrals which can be selected from, and build the initial appointment journey.
- Figure out the overlap between this and the manager journey, which @Gweaton will build.

# Screenshots

![Screenshot_2020-09-14 Referral details](https://user-images.githubusercontent.com/53756884/93083802-0d2a8980-f68b-11ea-9a99-137591aae47b.png)
![Screenshot_2020-09-14 Manage intervention referrals](https://user-images.githubusercontent.com/53756884/93083807-0ef44d00-f68b-11ea-98fd-d361c4cff1d2.png)
![Screenshot_2020-09-14 Action plan sent](https://user-images.githubusercontent.com/53756884/93083810-10257a00-f68b-11ea-99d1-f35c7e2cfede.png)
![Screenshot_2020-09-14 Session 1 assessment](https://user-images.githubusercontent.com/53756884/93083812-10be1080-f68b-11ea-9347-82eab1b51538.png)
![Screenshot_2020-09-14 End of service report](https://user-images.githubusercontent.com/53756884/93083815-10be1080-f68b-11ea-99ac-7c43092810ff.png)
