### PR TITLE
A caseworker can view a list of referrals

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -21,6 +21,8 @@ Example usage:
 module.exports = {
   referrals: [
     {
+      reference: "NR0001",
+
       interventions: [
 	{
 	  name: "Accommodation",

--- a/app/views/book-and-manage/manage-a-referral/caseworker/referral.html
+++ b/app/views/book-and-manage/manage-a-referral/caseworker/referral.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block beforeContent %}
-  <a href="#" class="govuk-back-link">Return to cases and referrals</a>
+  <a href="/book-and-manage/manage-a-referral/caseworker/referrals" class="govuk-back-link">Return to cases and referrals</a>
 {% endblock %}
 
 {% block content %}

--- a/app/views/book-and-manage/manage-a-referral/caseworker/referrals.html
+++ b/app/views/book-and-manage/manage-a-referral/caseworker/referrals.html
@@ -1,0 +1,85 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Cases and referrals
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column">
+      <div class="govuk-tabs" data-module="govuk-tabs">
+	<h2 class="govuk-tabs__title">
+	  Contents
+	</h2>
+	<ul class="govuk-tabs__list">
+	  <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+	    <a class="govuk-tabs__tab" href="#recently-added">
+	      Recently added referrals
+	    </a>
+	  </li>
+	  <li class="govuk-tabs__list-item">
+	    <a class="govuk-tabs__tab" href="#ongoing">
+	      Ongoing cases
+	    </a>
+	  </li>
+	  <li class="govuk-tabs__list-item">
+	    <a class="govuk-tabs__tab" href="#complete">
+	      Complete cases
+	    </a>
+	  </li>
+	  <li class="govuk-tabs__list-item">
+	    <a class="govuk-tabs__tab" href="#breach">
+	      Breach cases
+	    </a>
+	  </li>
+	</ul>
+
+	<div class="govuk-tabs__panel" id="recently-added">
+	  <h2 class="govuk-heading-l">Referrals awaiting assessment</h2>
+	  <table class="govuk-table">
+	    <thead class="govuk-table__head">
+	      <tr class="govuk-table__row">
+		<th scope="col" class="govuk-table__header">Referral</th>
+		<th scope="col" class="govuk-table__header">Service user</th>
+		<th scope="col" class="govuk-table__header">Probation practitioner</th>
+		<th scope="col" class="govuk-table__header">Status</th>
+	      </tr>
+	    </thead>
+	    <tbody class="govuk-table__body">
+	      {% for referral in data.referrals %}
+		<tr class="govuk-table__row">
+		  <td class="govuk-table__cell"><a href="/book-and-manage/manage-a-referral/caseworker/referrals/{{loop.index0}}">{{referral.reference}}</a></td>
+		  <td class="govuk-table__cell">Alex River</td>
+		  <td class="govuk-table__cell">Jessica Reel</td>
+		  <td class="govuk-table__cell">Not started</td>
+		</tr>
+	      {% endfor %}
+	    </tbody>
+	  </table>
+
+	  <h2 class="govuk-heading-l">Next assessment appointment</h2>
+	  <p class="govuk-body">To-do</p>
+	</div>
+
+	<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="ongoing">
+	  <h2 class="govuk-heading-l">Ongoing cases</h2>
+
+	  <p class="govuk-body">To-do</p>
+	</div>
+
+	<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="complete">
+	  <h2 class="govuk-heading-l">Complete cases</h2>
+
+	  <p class="govuk-body">To-do</p>
+	</div>
+
+	<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="breach">
+	  <h2 class="govuk-heading-l">Breach cases</h2>
+
+	  <p class="govuk-body">To-do</p>
+	</div>
+      </div>
+
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -43,7 +43,7 @@
               <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
             </svg>
           </a>
-          <a href="book-and-manage/manage-a-referral/caseworker/referrals/0" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+          <a href="book-and-manage/manage-a-referral/caseworker/referrals" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
             Case worker: manage intervention referrals
             <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
               <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>


### PR DESCRIPTION
# What's new

This shows the caseworker a list of all the referrals, labelling them as
”referrals awaiting assessment”. It gives us an obvious starting page
for the prototype.

Further work is needed to discern the meaning of (and populate), the
different statuses, and hence to populate the other lists.

# Screenshots

![image](https://user-images.githubusercontent.com/53756884/93113247-d9625a80-f6b0-11ea-89b1-23745dddcc7a.png)
![image](https://user-images.githubusercontent.com/53756884/93113120-b2a42400-f6b0-11ea-9045-9b29216817c4.png)
