### PR TITLE
[Sprint 4] Referral header tweaks

### DIFF
--- a/app/assets/sass/components/_referral-header.scss
+++ b/app/assets/sass/components/_referral-header.scss
@@ -23,6 +23,11 @@
     margin-left: govuk-spacing(2);
     content: "|";
   }
+  .govuk-width-container-sprint-3 {
+    @include govuk-width-container;
+    display: flex;
+  }
+
   .govuk-width-container {
     @include govuk-width-container(1100px);
     display: flex;
@@ -67,6 +72,11 @@
     font-weight: $govuk-font-weight-bold;
     margin-right: govuk-spacing(5);
   }
+
+  .govuk-width-container-sprint-3 {
+    @include govuk-width-container;
+  }
+
   .govuk-width-container {
     @include govuk-width-container(1100px);
   }

--- a/app/assets/sass/components/_referral-header.scss
+++ b/app/assets/sass/components/_referral-header.scss
@@ -19,9 +19,14 @@
     margin-left: govuk-spacing(2);
     margin-right: govuk-spacing(2);
   }
-
+  .right-bordered::after {
+    margin-left: govuk-spacing(2);
+    content: "|";
+  }
   .govuk-width-container {
+    @include govuk-width-container(1100px);
     display: flex;
+    flex-wrap: nowrap;
   }
 }
 
@@ -61,5 +66,8 @@
     color: inherit;
     font-weight: $govuk-font-weight-bold;
     margin-right: govuk-spacing(5);
+  }
+  .govuk-width-container {
+    @include govuk-width-container(1100px);
   }
 }

--- a/app/views/sprint-3/book-and-manage/manage-a-referral/includes/referral-header.html
+++ b/app/views/sprint-3/book-and-manage/manage-a-referral/includes/referral-header.html
@@ -1,5 +1,5 @@
 <dl class="app-referral-header__referral">
-  <div class="govuk-width-container">
+  <div class="govuk-width-container-sprint-3">
     <dt>Referral</dt>
     <dd>NR0001</dd>
 
@@ -12,7 +12,7 @@
 </dl>
 
 <div class="app-referral-header__service-user">
-  <div class="govuk-width-container">
+  <div class="govuk-width-container-sprint-3">
     <span>Mr Alex River</span>
 
     <dl>

--- a/app/views/sprint-4/book-and-manage/manage-a-referral/includes/referral-header.html
+++ b/app/views/sprint-4/book-and-manage/manage-a-referral/includes/referral-header.html
@@ -1,13 +1,17 @@
 <dl class="app-referral-header__referral">
   <div class="govuk-width-container {{ containerClasses }}">
     <dt>Referral</dt>
-    <dd>{{ referral.reference }}</dd>
+    <dd class="right-bordered">{{ referral.reference }}</dd>
 
-    <dt>Referral status</dt>
+    <dt>Intervention</dt>
+    <dd>{{ intervention.name }}</dd>
+
+    <dt>Status</dt>
     <dd>{{ intervention.status | default("in progress") }}</dd>
 
     <dt>Probation practitioner</dt>
-    <dd>{{ referral.probationPractitioner.name }}</dd>
+    <dd>{{ referral.probationPractitioner.name }} | {{ referral.probationPractitioner.phone }} | {{ referral.probationPractitioner.email }}</dd>
+
   </div>
 </dl>
 
@@ -16,17 +20,8 @@
     <span>{{ referral.serviceUser.title }} {{ referral.serviceUser.name }}</span>
 
     <dl>
-      <dt>Date of birth</dt>
-      <dd>08/05/1986</dd>
-
-      <dt>Email address</dt>
-      <dd>{{ referral.serviceUser.email }}</dd>
-
-      <dt>Contact number</dt>
-      <dd>{{ referral.serviceUser.phone }}</dd>
-
-      <dt>Gender</dt>
-      <dd>{{ referral.serviceUser.gender }}</dd>
+      <dt>Contact details</dt>
+      <dd>{{ referral.serviceUser.email }} | {{ referral.serviceUser.phone }}</dd>
 
       <dt>CRN</dt>
       <dd>DX12340A</dd>

--- a/app/views/sprint-4/book-and-manage/manage-a-referral/manager/confirm-details.html
+++ b/app/views/sprint-4/book-and-manage/manage-a-referral/manager/confirm-details.html
@@ -90,5 +90,18 @@
         <input type="submit" class="govuk-button" value="Confirm and assign intervention">
       </form>
     </div>
+
+    <div class="govuk-grid-column-one-third govuk-panel govuk-panel--sidebar">
+      <h2>Subsection</h2>
+      <p>
+        <a class="govuk-link" href="/sprint-4/book-and-manage/manage-a-referral/manager/referrals/{{referralIndex}}/interventions/{{interventionId}}/send-email">Send email to probation practitioner</a>
+      </p>
+      <p>
+        <a class="govuk-link" href="/sprint-4/book-and-manage/manage-a-referral/manager/referrals/{{referralIndex}}/interventions/{{interventionId}}/upload-case-notes">Add case notes</a>
+      </p>
+      <p>
+        <a class="govuk-link" href="/sprint-4/book-and-manage/manage-a-referral/manager/referrals/{{referralIndex}}/interventions/{{interventionId}}/communication-archive">View communication history</a>
+      </p>
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Changes in this PR

Lines up the prototype with the latest designs on Figma, removing some information about service users and adding more info about the probation practitioner.

There are a couple of issues with text overrunning to the next line on smaller screens as it's a long header, but hopefully this is good enough for now and to test a bit.

## Screenshot

![image](https://user-images.githubusercontent.com/19826940/94552898-96c38500-024f-11eb-946c-6c9b3416f37a.png)
