### PR TITLE
Add PNC, CRN & Nomis number to user details

### DIFF
--- a/app/data/session-data-defaults.js
+++ b/app/data/session-data-defaults.js
@@ -147,6 +147,9 @@ function createReferral(params, index) {
         disabilities: "Autism spectrum condition",
         email: "alex.river@gmail.com",
         phone: "07588 382 222",
+        pncNumber: "2014/1234786A",
+        crn: "D016868",
+        nomisNumber: "0203394",
         risks: {
           OGRSScore: "50",
           RM2000Score: "Medium",

--- a/app/views/sprint-4/book-and-manage/manage-a-referral/includes/referral-header.html
+++ b/app/views/sprint-4/book-and-manage/manage-a-referral/includes/referral-header.html
@@ -24,13 +24,13 @@
       <dd>{{ referral.serviceUser.email }} | {{ referral.serviceUser.phone }}</dd>
 
       <dt>CRN</dt>
-      <dd>DX12340A</dd>
+      <dd>{{ referral.serviceUser.crn }}</dd>
 
       <dt>PNC</dt>
-      <dd>A1234560A</dd>
+      <dd>{{ referral.serviceUser.pncNumber }}</dd>
 
       <dt>NOMIS</dt>
-      <dd>0203394</dd>
+      <dd>{{ referral.serviceUser.nomisNumber }}</dd>
     </dl>
   </div>
 </div>

--- a/app/views/sprint-4/book-and-manage/manage-a-referral/manager/includes/personal-details.html
+++ b/app/views/sprint-4/book-and-manage/manage-a-referral/manager/includes/personal-details.html
@@ -1,12 +1,53 @@
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key govuk-!-width-one-third">
+      Title
+    </dt>
+    <dd class="govuk-summary-list__value">
+      {{ serviceUser.title }}
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-!-width-one-third">
+      Name
+    </dt>
+    <dd class="govuk-summary-list__value">
+      {{ serviceUser.name }}
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-!-width-one-third">
       Other names
     </dt>
     <dd class="govuk-summary-list__value">
       {{ serviceUser.otherNames }}
     </dd>
   </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-!-width-one-third">
+      PNC number
+    </dt>
+    <dd class="govuk-summary-list__value">
+      {{ serviceUser.pncNumber }}
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-!-width-one-third">
+      CRN
+    </dt>
+    <dd class="govuk-summary-list__value">
+      {{ serviceUser.crn }}
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key govuk-!-width-one-third">
+      Nomis number
+    </dt>
+    <dd class="govuk-summary-list__value">
+      {{ serviceUser.nomisNumber }}
+    </dd>
+  </div>
+
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key govuk-!-width-one-third">
       Address


### PR DESCRIPTION
These are now populated from static data in:
- Interventions page user details section
- Referral header